### PR TITLE
Changes for AnyConnect 4.6.

### DIFF
--- a/src/netfilter_interface.c
+++ b/src/netfilter_interface.c
@@ -75,7 +75,11 @@ error_code register_ip_hooks(void)
 	for (counter = 0; counter < total_hooks; ++counter)
 		ip_hooks[counter].hook = hook_callback;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0))
+	hook_stat = nf_register_net_hooks(&init_net, ip_hooks, total_hooks);
+#else
 	hook_stat = nf_register_hooks(ip_hooks, total_hooks);
+#endif
 	if (0 != hook_stat) {
 		TRACE(ERROR,
 		      LOG("failed to register hooks error: %d", hook_stat));
@@ -89,7 +93,11 @@ error_code register_ip_hooks(void)
 */
 error_code deregister_ip_hooks(void)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0))
+	nf_unregister_net_hooks(&init_net, ip_hooks, ARRAY_SIZE(ip_hooks));
+#else
 	nf_unregister_hooks(ip_hooks, ARRAY_SIZE(ip_hooks));
+#endif
 	return SUCCESS;
 }
 

--- a/src/nvm_plugin.h
+++ b/src/nvm_plugin.h
@@ -50,6 +50,7 @@ struct TrackAppFlow {
 	uint8_t sent_flags;	/* a bitset of all TCP flags sent. */
 	uint8_t recv_flags;	/* similar to sent_flags, just received. */
 	bool finished;		/* Marks a tracking object for disposal. */
+	bool connected;		/* True if TCP connection is established.*/
 	/* timestamp for the last packet tracked for this flow */
 	uint32_t last_timestamp;
 };

--- a/src/nvm_user_kernel_types.h
+++ b/src/nvm_user_kernel_types.h
@@ -70,6 +70,7 @@ struct nvm_io_ctrl {
  * data that is passed for each unique flow to the userspace application*/
 
 #define APPFLOW_FILE_NAME_LEN           260
+#define APPFLOW_FILE_PATH_LEN           2048
 #define NVM_APPFLOW_VERSION             1
 #define NVM_FLOW_DIRECTION_UNKNOWN      0
 #define NVM_FLOW_DIRECTION_IN           1
@@ -84,6 +85,7 @@ enum flow_report_stage {
 
 /* NVM message types - messages sent to user space*/
 #define NVM_MESSAGE_APPFLOW_DATA  1
+#define NVM_MESSAGE_PID_INFO  2
 
 struct nvm_message_header {
 	uint16_t length;
@@ -108,12 +110,32 @@ struct app_flow {
 	uint32_t end_time;	/* time when socket was closed */
 
 	uint16_t file_name_len;
+	uint16_t file_path_len;
 	char file_name[APPFLOW_FILE_NAME_LEN];	/* null terminated image name*/
+	char file_path[APPFLOW_FILE_PATH_LEN];	/* null terminated image path*/
 	uint16_t parent_file_name_len;
+	uint16_t parent_file_path_len;
 	char parent_file_name[APPFLOW_FILE_NAME_LEN];
+	char parent_file_path[APPFLOW_FILE_PATH_LEN];
 	uint8_t direction;
 
 	enum flow_report_stage stage;
+};
+
+struct nvm_pid_info {
+    struct nvm_message_header header;
+    uint32_t pid;
+    uint32_t parent_pid;
+
+    uint16_t file_name_len;
+    uint16_t file_path_len;
+    char file_name[APPFLOW_FILE_NAME_LEN];	/* null terminated image name*/
+    char file_path[APPFLOW_FILE_PATH_LEN];	/* null terminated image path*/
+    uint16_t parent_file_name_len;
+    uint16_t parent_file_path_len;
+    char parent_file_name[APPFLOW_FILE_NAME_LEN];
+    char parent_file_path[APPFLOW_FILE_PATH_LEN];
+
 };
 
 #endif				/* __NVM_USER_KERNEL_TYPES_H__ */

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,6 +32,8 @@
 #include <linux/version.h>
 #include <linux/hashtable.h>
 
+extern const char *default_name;
+
 /*
  * Task methods
  */


### PR DESCRIPTION
1. nf_register_hooks removed from linux/net/netfilter/core.c
   Fixing the nf_register_hooks with nf_register_net_hooks.
2. Fix for KDF is reporting truncated process names
3. get_task_comm api changed in the kernel (4.15+)
   Fix for KDF module build error